### PR TITLE
swapfile improvement

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,3 +61,6 @@ ${SYNCOVERY_BIN} SET /INI=${SYNCOVERY_HOME}/Syncovery.cfg /WEBSERVER=localhost /
 # Change owner files and permissions
 chown -R root:root ${path_des}
 chmod -R a+rw ${SYNCOVERY_HOME}
+
+# Creates a 1GB swapfile
+[ ! -f $path_des/.swapfile.swp ] && { dd if=/dev/zero of=$path_des/.swapfile.swp bs=10M count=100 ; mkswap $path_des/.swapfile.swp; }

--- a/start.sh
+++ b/start.sh
@@ -22,3 +22,7 @@ if [[ -n "${PID}" ]]; then
 fi
 
 busybox nohup ${SYNCOVERY_BIN} SET /INI=${SYNCOVERY_HOME}/Syncovery.cfg 2>&1 >${SYNCOVERY_HOME}/start.log &
+
+# Enable swap
+SWP=$(cat /proc/swaps | grep "$path/.swapfile.swp")
+[ -z "$SWP" ] && swapon $path/.swapfile.swp;

--- a/stop.sh
+++ b/stop.sh
@@ -22,3 +22,7 @@ sleep 10;
 
 PID=$(/bin/ps -eo 'pid,cmd' | grep 'SyncoveryCL' | grep -v grep | awk '{ print $1 }')
 [[ -n "${PID}" ]] && kill ${PID}
+
+# Disable swap
+SWP=$(cat /proc/swaps | grep "$path/.swapfile.swp")
+[ ! -z "$SWP" ] && swapoff $path/.swapfile.swp;


### PR DESCRIPTION
Add swapfile improvement. After sync a lot of files, the nas stopped working due lack of memory. Now theses scripts create a swapfile of 1GB, and enable it when starts Syncovery.